### PR TITLE
Allow custom file types in Directory component

### DIFF
--- a/src/backend/base/langflow/components/data/directory.py
+++ b/src/backend/base/langflow/components/data/directory.py
@@ -26,6 +26,7 @@ class DirectoryComponent(Component):
             info="File types to load. Select one or more types or leave empty to load all supported types.",
             options=TEXT_FILE_TYPES,
             value=[],
+            combobox=True,
         ),
         IntInput(
             name="depth",
@@ -86,12 +87,9 @@ class DirectoryComponent(Component):
         # If no types are specified, use all supported types
         if not types:
             types = TEXT_FILE_TYPES
-
-        # Check if all specified types are valid
-        invalid_types = [t for t in types if t not in TEXT_FILE_TYPES]
-        if invalid_types:
-            msg = f"Invalid file types specified: {invalid_types}. Valid types are: {TEXT_FILE_TYPES}"
-            raise ValueError(msg)
+        else:
+            # Allow custom file types; remove duplicates
+            types = list(dict.fromkeys(types))
 
         valid_types = types
 

--- a/src/backend/tests/unit/components/data/test_directory_component.py
+++ b/src/backend/tests/unit/components/data/test_directory_component.py
@@ -286,13 +286,9 @@ class TestDirectoryComponent(ComponentTestBaseWithoutClient):
                 }
             )
 
-            with pytest.raises(
-                ValueError, match="Invalid file types specified: \\['exe'\\]. Valid types are:"
-            ) as exc_info:
-                directory_component.load_directory()
-
-            assert "Invalid file types specified: ['exe']" in str(exc_info.value)
-            assert "Valid types are:" in str(exc_info.value)
+            results = directory_component.load_directory()
+            assert len(results) == 1
+            assert Path(results[0].data["file_path"]).suffix == ".exe"
 
     def test_directory_with_hidden_files(self):
         """Test DirectoryComponent with hidden files."""


### PR DESCRIPTION
## Summary
- allow custom values for Directory file types by enabling combobox mode
- remove restriction on file types to accept user supplied extensions
- adjust Directory tests accordingly

## Testing
- `ruff check src/backend/base/langflow/components/data/directory.py src/backend/tests/unit/components/data/test_directory_component.py`
- `make unit_tests` *(fails: No route to host)*