### PR TITLE
Implement base path for Directory component

### DIFF
--- a/docs/docs/Components/components-data.md
+++ b/docs/docs/Components/components-data.md
@@ -84,7 +84,8 @@ This component recursively loads files from a directory, with options for file t
 
 | Input              | Type             | Description                                        |
 | ------------------ | ---------------- | -------------------------------------------------- |
-| path               | MessageTextInput | The path to the directory to load files from.      |
+| path               | MessageTextInput | The path to the directory to load files from. Relative to `base_path` when provided. |
+| base_path          | MessageTextInput | Base directory used to resolve `path`. |
 | types              | MessageTextInput | The file types to load (leave empty to load all types). |
 | depth              | IntInput         | The depth to search for files.                     |
 | max_concurrency    | IntInput         | The maximum concurrency for loading files.         |
@@ -97,7 +98,7 @@ This component recursively loads files from a directory, with options for file t
 
 | Output | Type       | Description                         |
 | ------ | ---------- | ----------------------------------- |
-| data   | List[Data] | The loaded file data from the directory. |
+| data   | List[Data] | The loaded file data from the directory. Each item includes `file_path`, `relative_path`, and `base_path`. |
 | dataframe | DataFrame | The loaded file data in tabular DataFrame format. |
 
 </details>

--- a/src/backend/base/langflow/components/data/directory.py
+++ b/src/backend/base/langflow/components/data/directory.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from langflow.base.data.utils import TEXT_FILE_TYPES, parallel_load_data, parse_text_file_to_data, retrieve_file_paths
 from langflow.custom import Component
 from langflow.io import (
@@ -25,6 +27,12 @@ class DirectoryComponent(Component):
             info="Path to the directory to load files from. Defaults to current directory ('.')",
             value=".",
             tool_mode=True,
+        ),
+        MessageTextInput(
+            name="base_path",
+            display_name="Base Path",
+            info="Base directory used to resolve the path relative to.",
+            advanced=True,
         ),
         MultiselectInput(
             name="types",
@@ -92,6 +100,7 @@ class DirectoryComponent(Component):
 
     def load_directory(self) -> list[Data]:
         path = self.path
+        base_path = self.base_path
         types = self.types
         depth = self.depth
         max_concurrency = self.max_concurrency
@@ -102,7 +111,12 @@ class DirectoryComponent(Component):
         whitelist_filters = self.whitelist_filters
         blacklist_filters = self.blacklist_filters
 
-        resolved_path = self.resolve_path(path)
+        if base_path:
+            resolved_base_path = self.resolve_path(base_path)
+            resolved_path = self.resolve_path(str(Path(resolved_base_path) / path))
+        else:
+            resolved_base_path = ""
+            resolved_path = self.resolve_path(path)
 
         # If no types are specified, use all supported types
         types = TEXT_FILE_TYPES if not types else list(dict.fromkeys(types))
@@ -124,6 +138,8 @@ class DirectoryComponent(Component):
             blacklist_regexes=parse_filters(blacklist_filters),
         )
 
+        base_for_data = resolved_base_path if resolved_base_path else resolved_path
+
         loaded_data = []
         if use_multithreading:
             loaded_data = parallel_load_data(
@@ -133,7 +149,7 @@ class DirectoryComponent(Component):
                 load_function=lambda fp, *, silent_errors: parse_text_file_to_data(
                     fp,
                     silent_errors=silent_errors,
-                    base_path=resolved_path,
+                    base_path=base_for_data,
                 ),
             )
         else:
@@ -141,7 +157,7 @@ class DirectoryComponent(Component):
                 parse_text_file_to_data(
                     file_path,
                     silent_errors=silent_errors,
-                    base_path=resolved_path,
+                    base_path=base_for_data,
                 )
                 for file_path in file_paths
             ]

--- a/src/backend/tests/unit/components/data/test_directory_component.py
+++ b/src/backend/tests/unit/components/data/test_directory_component.py
@@ -388,7 +388,8 @@ class TestDirectoryComponent(ComponentTestBaseWithoutClient):
 
             directory_component.set_attributes(
                 {
-                    "path": str(base),
+                    "base_path": str(base),
+                    "path": ".",
                     "use_multithreading": False,
                     "recursive": True,
                     "types": ["txt"],
@@ -401,7 +402,8 @@ class TestDirectoryComponent(ComponentTestBaseWithoutClient):
             assert "root.txt" in rel_paths
             assert "sub/child.txt" in rel_paths
             assert all(r.data.get("base_path") == str(base) for r in results)
-            assert all(str(base) in r.data.get("file_path") for r in results)
+            expected_full = {str(base / rp) for rp in rel_paths}
+            assert {r.data.get("file_path") for r in results} == expected_full
 
     def test_directory_regex_filters(self):
         directory_component = DirectoryComponent()


### PR DESCRIPTION
## Summary
- add optional `base_path` input to Directory component
- compute paths relative to provided base path
- ensure relative path column always relates to base path
- document new parameter and output information
- update tests for new behaviour

## Testing
- `make unit_tests` *(fails: No route to host)*