### PR TITLE
Implement base path for Directory component

### DIFF
--- a/docs/docs/Components/components-data.md
+++ b/docs/docs/Components/components-data.md
@@ -84,7 +84,8 @@ This component recursively loads files from a directory, with options for file t
 
 | Input              | Type             | Description                                        |
 | ------------------ | ---------------- | -------------------------------------------------- |
-| path               | MessageTextInput | The path to the directory to load files from.      |
+| path               | MessageTextInput | The path to the directory to load files from. Relative to `base_path` when provided. |
+| base_path          | MessageTextInput | Base directory used to resolve `path`. |
 | types              | MessageTextInput | The file types to load (leave empty to load all types). |
 | depth              | IntInput         | The depth to search for files.                     |
 | max_concurrency    | IntInput         | The maximum concurrency for loading files.         |
@@ -97,7 +98,7 @@ This component recursively loads files from a directory, with options for file t
 
 | Output | Type       | Description                         |
 | ------ | ---------- | ----------------------------------- |
-| data   | List[Data] | The loaded file data from the directory. |
+| data   | List[Data] | The loaded file data from the directory. Each item includes `file_path` and, when `base_path` is provided, `relative_path`. |
 | dataframe | DataFrame | The loaded file data in tabular DataFrame format. |
 
 </details>

--- a/src/backend/base/langflow/base/data/utils.py
+++ b/src/backend/base/langflow/base/data/utils.py
@@ -189,10 +189,11 @@ def parse_text_file_to_data(
     data = {"file_path": file_path, "text": text}
     if base_path:
         try:
-            data["relative_path"] = str(Path(file_path).resolve().relative_to(Path(base_path).resolve()))
+            relative = str(Path(file_path).resolve().relative_to(Path(base_path).resolve()))
         except ValueError:
-            data["relative_path"] = str(Path(file_path).name)
-        data["base_path"] = str(Path(base_path))
+            relative = str(Path(file_path).name)
+        if relative:
+            data["relative_path"] = relative
     return Data(data=data)
 
 

--- a/src/backend/tests/unit/components/data/test_directory_component.py
+++ b/src/backend/tests/unit/components/data/test_directory_component.py
@@ -388,7 +388,8 @@ class TestDirectoryComponent(ComponentTestBaseWithoutClient):
 
             directory_component.set_attributes(
                 {
-                    "path": str(base),
+                    "base_path": str(base),
+                    "path": ".",
                     "use_multithreading": False,
                     "recursive": True,
                     "types": ["txt"],
@@ -400,8 +401,8 @@ class TestDirectoryComponent(ComponentTestBaseWithoutClient):
             rel_paths = {r.data.get("relative_path") for r in results}
             assert "root.txt" in rel_paths
             assert "sub/child.txt" in rel_paths
-            assert all(r.data.get("base_path") == str(base) for r in results)
-            assert all(str(base) in r.data.get("file_path") for r in results)
+            expected_full = {str(base / rp) for rp in rel_paths}
+            assert {r.data.get("file_path") for r in results} == expected_full
 
     def test_directory_regex_filters(self):
         directory_component = DirectoryComponent()


### PR DESCRIPTION
## Summary
- add optional `base_path` input to Directory component
- compute paths relative to provided base path without adding `base_path` to the output
- document new behaviour of returned `relative_path`
- update tests for new behaviour

## Testing
- `make unit_tests` *(fails: No route to host)*