### PR TITLE
Add dataframe merge and append operations

### DIFF
--- a/docs/docs/Components/components-processing.md
+++ b/docs/docs/Components/components-processing.md
@@ -101,6 +101,8 @@ This component can perform the following operations on Pandas [DataFrame](https:
 | Select Columns | Selects specific columns | columns_to_select |
 | Sort | Sorts DataFrame by column | column_name, ascending |
 | Tail | Returns last n rows | num_rows |
+| Append | Appends another DataFrame | other_df |
+| Merge | Merges with another DataFrame on a column | other_df, merge_on |
 
 <details>
 <summary>Parameters</summary>
@@ -110,7 +112,9 @@ This component can perform the following operations on Pandas [DataFrame](https:
 | Name | Display Name | Info |
 |------|--------------|------|
 | df | DataFrame | The input DataFrame to operate on. |
-| operation | Operation | The DataFrame operation to perform. Options include Add Column, Drop Column, Filter, Head, Rename Column, Replace Value, Select Columns, Sort, and Tail. |
+| operation | Operation | The DataFrame operation to perform. Options include Add Column, Drop Column, Filter, Head, Rename Column, Replace Value, Select Columns, Sort, Tail, Append, and Merge. |
+| other_df | Other DataFrame | The second DataFrame for Append or Merge operations. |
+| merge_on | Merge On Column | Column to merge on when performing a Merge operation. |
 | column_name | Column Name | The column name to use for the operation. |
 | filter_value | Filter Value | The value to filter rows by. |
 | ascending | Sort Ascending | Whether to sort in ascending order. |

--- a/src/backend/base/langflow/components/processing/data_operations.py
+++ b/src/backend/base/langflow/components/processing/data_operations.py
@@ -20,6 +20,7 @@ ACTION_CONFIG = {
     "Append or Update": {"is_list": False, "log_msg": "setting Append or Update fields"},
     "Remove Keys": {"is_list": False, "log_msg": "setting remove keys fields"},
     "Rename Keys": {"is_list": False, "log_msg": "setting rename keys fields"},
+    "Join Data": {"is_list": True, "log_msg": "setting join data fields"},
 }
 OPERATORS = {
     "equals": lambda a, b: str(a) == str(b),
@@ -68,6 +69,7 @@ class DataOperationsComponent(Component):
         "Append or Update": ["append_update_data", "operations"],
         "Remove Keys": ["remove_keys_input", "operations"],
         "Rename Keys": ["rename_keys_input", "operations"],
+        "Join Data": [],
     }
 
     inputs = [
@@ -85,6 +87,7 @@ class DataOperationsComponent(Component):
                 {"name": "Append or Update", "icon": "circle-plus"},
                 {"name": "Remove Keys", "icon": "eraser"},
                 {"name": "Rename Keys", "icon": "pencil-line"},
+                {"name": "Join Data", "icon": "merge"},
             ],
             real_time_refresh=True,
             limit=1,
@@ -363,6 +366,15 @@ class DataOperationsComponent(Component):
 
         return Data(**data_filtered)
 
+    def join_data(self) -> Data:
+        """Join multiple Data objects into one."""
+        if not self.data_is_list():
+            return self.data[0] if self.data else Data(data={})
+        result = self.data[0]
+        for other in self.data[1:]:
+            result = result + other
+        return result
+
     # Configuration and execution methods
     def update_build_config(self, build_config: dotdict, field_value: Any, field_name: str | None = None) -> dotdict:
         """Update build configuration based on selected action."""
@@ -424,6 +436,7 @@ class DataOperationsComponent(Component):
             "Append or Update": self.append_update,
             "Remove Keys": self.remove_keys,
             "Rename Keys": self.rename_keys,
+            "Join Data": self.join_data,
         }
 
         handler: Callable[[], Data] | None = action_map.get(action)

--- a/src/backend/base/langflow/components/processing/dataframe_operations.py
+++ b/src/backend/base/langflow/components/processing/dataframe_operations.py
@@ -1,5 +1,14 @@
+import pandas as pd
 from langflow.custom import Component
-from langflow.io import BoolInput, DataFrameInput, DropdownInput, IntInput, MessageTextInput, Output, StrInput
+from langflow.io import (
+    BoolInput,
+    DataFrameInput,
+    DropdownInput,
+    IntInput,
+    MessageTextInput,
+    Output,
+    StrInput,
+)
 from langflow.schema import DataFrame
 
 
@@ -19,6 +28,8 @@ class DataFrameOperationsComponent(Component):
         "Select Columns",
         "Sort",
         "Tail",
+        "Append",
+        "Merge",
     ]
 
     inputs = [
@@ -26,6 +37,13 @@ class DataFrameOperationsComponent(Component):
             name="df",
             display_name="DataFrame",
             info="The input DataFrame to operate on.",
+        ),
+        DataFrameInput(
+            name="other_df",
+            display_name="Other DataFrame",
+            info="Second DataFrame for append or merge operations.",
+            show=False,
+            dynamic=True,
         ),
         DropdownInput(
             name="operation",
@@ -99,6 +117,13 @@ class DataFrameOperationsComponent(Component):
             dynamic=True,
             show=False,
         ),
+        StrInput(
+            name="merge_on",
+            display_name="Merge On Column",
+            info="Column name to merge on when performing a merge operation.",
+            dynamic=True,
+            show=False,
+        ),
     ]
 
     outputs = [
@@ -122,6 +147,8 @@ class DataFrameOperationsComponent(Component):
             "num_rows",
             "replace_value",
             "replacement_value",
+            "other_df",
+            "merge_on",
         ]
         for field in dynamic_fields:
             build_config[field]["show"] = False
@@ -150,6 +177,10 @@ class DataFrameOperationsComponent(Component):
                 build_config["column_name"]["show"] = True
                 build_config["replace_value"]["show"] = True
                 build_config["replacement_value"]["show"] = True
+            elif field_value in {"Append", "Merge"}:
+                build_config["other_df"]["show"] = True
+                if field_value == "Merge":
+                    build_config["merge_on"]["show"] = True
 
         return build_config
 
@@ -175,6 +206,10 @@ class DataFrameOperationsComponent(Component):
             return self.tail(dataframe_copy)
         if operation == "Replace Value":
             return self.replace_values(dataframe_copy)
+        if operation == "Append":
+            return self.append_dataframe(dataframe_copy)
+        if operation == "Merge":
+            return self.merge_dataframes(dataframe_copy)
         msg = f"Unsupported operation: {operation}"
 
         raise ValueError(msg)
@@ -210,3 +245,18 @@ class DataFrameOperationsComponent(Component):
     def replace_values(self, df: DataFrame) -> DataFrame:
         df[self.column_name] = df[self.column_name].replace(self.replace_value, self.replacement_value)
         return DataFrame(df)
+
+    def append_dataframe(self, df: DataFrame) -> DataFrame:
+        if self.other_df is None:
+            return df
+        appended = pd.concat([df, self.other_df], ignore_index=True)
+        return DataFrame(appended)
+
+    def merge_dataframes(self, df: DataFrame) -> DataFrame:
+        if self.other_df is None:
+            return df
+        if not self.merge_on:
+            msg = "Merge operation requires 'merge_on' column"
+            raise ValueError(msg)
+        merged = df.merge(self.other_df, on=self.merge_on)
+        return DataFrame(merged)


### PR DESCRIPTION
## Summary
- support `Append` and `Merge` in DataFrame operations node
- allow joining multiple data objects via new `Join Data` action
- document new DataFrame operations

## Testing
- `make format_backend` *(fails: No route to host)*
- `make lint` *(fails: No route to host)*
- `make unit_tests` *(fails: No route to host)*