### PR TITLE
Add multi-text join node and multiline filters

### DIFF
--- a/src/backend/base/langflow/components/data/directory.py
+++ b/src/backend/base/langflow/components/data/directory.py
@@ -6,8 +6,8 @@ from langflow.io import (
     BoolInput,
     IntInput,
     MessageTextInput,
+    MultilineInput,
     MultiselectInput,
-    StrInput,
 )
 from langflow.schema import Data
 from langflow.schema.dataframe import DataFrame
@@ -79,13 +79,13 @@ class DirectoryComponent(Component):
             advanced=True,
             info="If true, multithreading will be used.",
         ),
-        StrInput(
+        MultilineInput(
             name="whitelist_filters",
             display_name="Whitelist Filters",
             info="Regex patterns (one per line) to include specific files.",
             advanced=True,
         ),
-        StrInput(
+        MultilineInput(
             name="blacklist_filters",
             display_name="Blacklist Filters",
             info="Regex patterns (one per line) to exclude specific files.",

--- a/src/backend/base/langflow/components/processing/__init__.py
+++ b/src/backend/base/langflow/components/processing/__init__.py
@@ -1,5 +1,6 @@
 from .alter_metadata import AlterMetadataComponent
 from .combine_text import CombineTextComponent
+from .join_texts import JoinTextsComponent
 from .create_data import CreateDataComponent
 from .data_operations import DataOperationsComponent
 from .directory_tree import DirectoryTreeComponent
@@ -38,6 +39,7 @@ __all__ = [
     "ParseJSONDataComponent",
     "ParserComponent",
     "RegexExtractorComponent",
+    "JoinTextsComponent",
     "SelectDataComponent",
     "SplitTextComponent",
     "UpdateDataComponent",

--- a/src/backend/base/langflow/components/processing/join_texts.py
+++ b/src/backend/base/langflow/components/processing/join_texts.py
@@ -1,0 +1,36 @@
+from langflow.custom import Component
+from langflow.io import MessageTextInput, MultilineInput, Output
+from langflow.schema.message import Message
+
+
+class JoinTextsComponent(Component):
+    display_name = "Join Texts"
+    description = "Join multiple text inputs into a single text using a delimiter."
+    icon = "merge"
+    name = "JoinTexts"
+
+    inputs = [
+        MessageTextInput(
+            name="texts",
+            display_name="Texts",
+            info="List of texts to concatenate.",
+            is_list=True,
+        ),
+        MultilineInput(
+            name="delimiter",
+            display_name="Delimiter",
+            info="Delimiter used to join texts.",
+            value="\n",
+        ),
+    ]
+
+    outputs = [
+        Output(display_name="Combined Text", name="combined_text", method="join_texts"),
+    ]
+
+    def join_texts(self) -> Message:
+        text_list = self.texts or []
+        delimiter = self.delimiter
+        combined = delimiter.join(str(text) for text in text_list)
+        self.status = combined
+        return Message(text=combined)


### PR DESCRIPTION
## Summary
- add `JoinTextsComponent` to concatenate multiple text inputs with a delimiter
- make directory whitelist and blacklist filters multiline

## Testing
- `ruff check --fix src/backend/base/langflow/components/processing/join_texts.py src/backend/base/langflow/components/data/directory.py`
- `ruff format src/backend/base/langflow/components/processing/join_texts.py src/backend/base/langflow/components/data/directory.py`
- `make unit_tests` *(fails: No route to host)*