### PR TITLE
Add structured output parsing

### DIFF
--- a/src/backend/base/langflow/components/models/openrouter.py
+++ b/src/backend/base/langflow/components/models/openrouter.py
@@ -1,3 +1,4 @@
+import json
 from collections import defaultdict
 from typing import Any
 
@@ -9,12 +10,15 @@ from langflow.base.models.model import LCModelComponent
 from langflow.field_typing import LanguageModel
 from langflow.field_typing.range_spec import RangeSpec
 from langflow.inputs import (
+    DictInput,
     DropdownInput,
     IntInput,
     SecretStrInput,
     SliderInput,
     StrInput,
 )
+from langflow.schema.data import Data
+from langflow.template.field.base import Output
 
 
 class OpenRouterComponent(LCModelComponent):
@@ -74,6 +78,21 @@ class OpenRouterComponent(LCModelComponent):
             display_name="Max Tokens",
             info="Maximum number of tokens to generate",
             advanced=True,
+        ),
+        DictInput(
+            name="response_schema",
+            display_name="Response Schema",
+            advanced=True,
+            info="JSON schema for structured outputs.",
+        ),
+    ]
+
+    outputs = [
+        *LCModelComponent.outputs,
+        Output(
+            name="structured_output",
+            display_name="Structured Output",
+            method="structured_output",
         ),
     ]
 
@@ -143,11 +162,28 @@ class OpenRouterComponent(LCModelComponent):
             kwargs["default_headers"] = headers
 
         try:
-            return ChatOpenAI(**kwargs)
+            output = ChatOpenAI(**kwargs)
         except (ValueError, httpx.HTTPError) as err:
             error_msg = f"Failed to build model: {err!s}"
             self.log(error_msg)
             raise ValueError(error_msg) from err
+
+        if self.response_schema:
+            output = output.bind(response_format={"type": "json_schema", **self.response_schema})
+        return output
+
+    def structured_output(self) -> Data:
+        result = self.get_chat_result(
+            runnable=self.build_model(),
+            stream=self.stream,
+            input_value=self.input_value,
+            system_message=self.system_message,
+        )
+        try:
+            parsed = json.loads(result) if isinstance(result, str) else result
+        except (ValueError, TypeError):
+            parsed = result
+        return Data(text_key="results", data={"results": parsed})
 
     def _get_exception_message(self, e: Exception) -> str | None:
         """Get a message from an OpenRouter exception.

--- a/src/backend/tests/unit/components/models/test_openai_chat_model.py
+++ b/src/backend/tests/unit/components/models/test_openai_chat_model.py
@@ -1,0 +1,67 @@
+from unittest.mock import MagicMock
+
+import pytest
+from langflow.components.models import OpenAIModelComponent
+
+from tests.base import ComponentTestBaseWithoutClient
+
+
+class TestOpenAIModelComponent(ComponentTestBaseWithoutClient):
+    @pytest.fixture
+    def component_class(self):
+        return OpenAIModelComponent
+
+    @pytest.fixture
+    def default_kwargs(self):
+        return {
+            "api_key": "test-key",
+            "model_name": "gpt-3.5-turbo",
+            "temperature": 0.1,
+            "max_tokens": 10,
+        }
+
+    @pytest.fixture
+    def file_names_mapping(self):
+        return []
+
+    def test_response_schema(self, component_class, mocker):
+        component = component_class()
+        component.api_key = "test-key"
+        component.response_schema = {
+            "name": "test",
+            "schema": {"type": "object", "properties": {}, "required": [], "additionalProperties": False},
+            "strict": True,
+        }
+        mock_instance = MagicMock()
+        mock_bound = MagicMock()
+        mock_instance.bind.return_value = mock_bound
+        mocker.patch("langflow.components.models.openai_chat_model.ChatOpenAI", return_value=mock_instance)
+
+        model = component.build_model()
+
+        mock_instance.bind.assert_called_once_with(response_format={"type": "json_schema", **component.response_schema})
+        assert list(mock_instance.bind.call_args.kwargs["response_format"].keys()) == [
+            "type",
+            "name",
+            "schema",
+            "strict",
+        ]
+        assert model == mock_bound
+
+    def test_structured_output(self, component_class, mocker):
+        component = component_class()
+        component.api_key = "test-key"
+        component.model_name = "gpt-3.5-turbo"
+        component.response_schema = {
+            "name": "test",
+            "schema": {"type": "object", "properties": {}, "required": [], "additionalProperties": False},
+            "strict": True,
+        }
+        mock_model = MagicMock()
+        mock_model.bind.return_value = mock_model
+        mocker.patch("langflow.components.models.openai_chat_model.ChatOpenAI", return_value=mock_model)
+        mocker.patch.object(component, "get_chat_result", return_value={"foo": "bar"})
+
+        data = component.structured_output()
+
+        assert data.data == {"results": {"foo": "bar"}}

--- a/src/backend/tests/unit/components/models/test_openrouter.py
+++ b/src/backend/tests/unit/components/models/test_openrouter.py
@@ -1,0 +1,68 @@
+from unittest.mock import MagicMock
+
+import pytest
+from langflow.components.models import OpenRouterComponent
+
+from tests.base import ComponentTestBaseWithoutClient
+
+
+class TestOpenRouterComponent(ComponentTestBaseWithoutClient):
+    @pytest.fixture
+    def component_class(self):
+        return OpenRouterComponent
+
+    @pytest.fixture
+    def default_kwargs(self):
+        return {
+            "api_key": "test-key",
+            "provider": "OpenAI",
+            "model_name": "openai/gpt-4o",
+            "temperature": 0.7,
+        }
+
+    @pytest.fixture
+    def file_names_mapping(self):
+        return []
+
+    def test_response_schema(self, component_class, mocker):
+        component = component_class()
+        component.api_key = "test-key"
+        component.model_name = "openai/gpt-4o"
+        component.response_schema = {
+            "name": "test",
+            "schema": {"type": "object", "properties": {}, "required": [], "additionalProperties": False},
+            "strict": True,
+        }
+        mock_instance = MagicMock()
+        mock_bound = MagicMock()
+        mock_instance.bind.return_value = mock_bound
+        mocker.patch("langflow.components.models.openrouter.ChatOpenAI", return_value=mock_instance)
+
+        model = component.build_model()
+
+        mock_instance.bind.assert_called_once_with(response_format={"type": "json_schema", **component.response_schema})
+        assert list(mock_instance.bind.call_args.kwargs["response_format"].keys()) == [
+            "type",
+            "name",
+            "schema",
+            "strict",
+        ]
+        assert model == mock_bound
+
+    def test_structured_output(self, component_class, mocker):
+        component = component_class()
+        component.api_key = "test-key"
+        component.model_name = "openai/gpt-4o"
+        component.response_schema = {
+            "name": "test",
+            "schema": {"type": "object", "properties": {}, "required": [], "additionalProperties": False},
+            "strict": True,
+        }
+        mock_model = MagicMock()
+        mock_model.bind.return_value = mock_model
+        mocker.patch("langflow.components.models.openrouter.ChatOpenAI", return_value=mock_model)
+        mocker.patch.object(component, "get_chat_result", return_value={"foo": "bar"})
+
+        data = component.structured_output()
+
+        assert data.data == {"results": {"foo": "bar"}}


### PR DESCRIPTION
## Summary
- add structured output output to OpenAI and OpenRouter nodes
- preserve schema key order when binding models
- test schema ordering and structured output

## Testing
- `ruff format src/backend/base/langflow/components/models/openai_chat_model.py src/backend/base/langflow/components/models/openrouter.py src/backend/tests/unit/components/models/test_openai_chat_model.py src/backend/tests/unit/components/models/test_openrouter.py`
- `ruff check src/backend/base/langflow/components/models/openai_chat_model.py src/backend/base/langflow/components/models/openrouter.py src/backend/tests/unit/components/models/test_openai_chat_model.py src/backend/tests/unit/components/models/test_openrouter.py`
- ❌ `pytest -k response_schema tests` *(fails: command not found)*