### PR TITLE
Add multi-text join node and multiline filters

### DIFF
--- a/src/backend/base/langflow/components/data/directory.py
+++ b/src/backend/base/langflow/components/data/directory.py
@@ -6,8 +6,8 @@ from langflow.io import (
     BoolInput,
     IntInput,
     MessageTextInput,
+    MultilineInput,
     MultiselectInput,
-    StrInput,
 )
 from langflow.schema import Data
 from langflow.schema.dataframe import DataFrame
@@ -79,13 +79,13 @@ class DirectoryComponent(Component):
             advanced=True,
             info="If true, multithreading will be used.",
         ),
-        StrInput(
+        MultilineInput(
             name="whitelist_filters",
             display_name="Whitelist Filters",
             info="Regex patterns (one per line) to include specific files.",
             advanced=True,
         ),
-        StrInput(
+        MultilineInput(
             name="blacklist_filters",
             display_name="Blacklist Filters",
             info="Regex patterns (one per line) to exclude specific files.",

--- a/src/backend/base/langflow/components/processing/__init__.py
+++ b/src/backend/base/langflow/components/processing/__init__.py
@@ -6,6 +6,7 @@ from .directory_tree import DirectoryTreeComponent
 from .extract_key import ExtractDataKeyComponent
 from .filter_data_values import DataFilterComponent
 from .format_directory_data import FormatDirectoryDataComponent
+from .join_texts import JoinTextsComponent
 from .json_cleaner import JSONCleaner
 from .lambda_filter import LambdaFilterComponent
 from .llm_router import LLMRouterComponent
@@ -17,6 +18,7 @@ from .parser import ParserComponent
 from .regex import RegexExtractorComponent
 from .select_data import SelectDataComponent
 from .split_text import SplitTextComponent
+from .text_operations import TextOperationsComponent
 from .update_data import UpdateDataComponent
 
 __all__ = [
@@ -29,6 +31,7 @@ __all__ = [
     "ExtractDataKeyComponent",
     "FormatDirectoryDataComponent",
     "JSONCleaner",
+    "JoinTextsComponent",
     "LLMRouterComponent",
     "LambdaFilterComponent",
     "MergeDataComponent",
@@ -40,5 +43,6 @@ __all__ = [
     "RegexExtractorComponent",
     "SelectDataComponent",
     "SplitTextComponent",
+    "TextOperationsComponent",
     "UpdateDataComponent",
 ]

--- a/src/backend/base/langflow/components/processing/join_texts.py
+++ b/src/backend/base/langflow/components/processing/join_texts.py
@@ -1,0 +1,36 @@
+from langflow.custom import Component
+from langflow.io import MessageTextInput, MultilineInput, Output
+from langflow.schema.message import Message
+
+
+class JoinTextsComponent(Component):
+    display_name = "Join Texts"
+    description = "Join multiple text inputs into a single text using a delimiter."
+    icon = "merge"
+    name = "JoinTexts"
+
+    inputs = [
+        MessageTextInput(
+            name="texts",
+            display_name="Texts",
+            info="List of texts to concatenate.",
+            is_list=True,
+        ),
+        MultilineInput(
+            name="delimiter",
+            display_name="Delimiter",
+            info="Delimiter used to join texts.",
+            value="\n",
+        ),
+    ]
+
+    outputs = [
+        Output(display_name="Combined Text", name="combined_text", method="join_texts"),
+    ]
+
+    def join_texts(self) -> Message:
+        text_list = self.texts or []
+        delimiter = self.delimiter
+        combined = delimiter.join(str(text) for text in text_list)
+        self.status = combined
+        return Message(text=combined)

--- a/src/backend/base/langflow/components/processing/text_operations.py
+++ b/src/backend/base/langflow/components/processing/text_operations.py
@@ -1,0 +1,114 @@
+from langflow.custom import Component
+from langflow.io import DropdownInput, MessageTextInput, MultilineInput, Output
+from langflow.schema.message import Message
+
+
+class TextOperationsComponent(Component):
+    display_name = "Text Operations"
+    description = "Perform various operations on text."
+    icon = "paragraph"
+    name = "TextOperations"
+
+    OPERATION_CHOICES = ["Join Texts", "Append", "Prepend", "Wrap"]
+
+    inputs = [
+        DropdownInput(
+            name="operation",
+            display_name="Operation",
+            options=OPERATION_CHOICES,
+            info="Select the text operation to perform.",
+            real_time_refresh=True,
+        ),
+        MessageTextInput(
+            name="text",
+            display_name="Text",
+            dynamic=True,
+            show=False,
+        ),
+        MessageTextInput(
+            name="texts",
+            display_name="Texts",
+            is_list=True,
+            dynamic=True,
+            show=False,
+        ),
+        MultilineInput(
+            name="delimiter",
+            display_name="Delimiter",
+            info="Delimiter used to join texts.",
+            value="\n",
+            show=False,
+        ),
+        MultilineInput(
+            name="append_text",
+            display_name="Append Text",
+            show=False,
+        ),
+        MultilineInput(
+            name="prepend_text",
+            display_name="Prepend Text",
+            show=False,
+        ),
+        MultilineInput(
+            name="prefix",
+            display_name="Prefix",
+            show=False,
+        ),
+        MultilineInput(
+            name="suffix",
+            display_name="Suffix",
+            show=False,
+        ),
+    ]
+
+    outputs = [
+        Output(display_name="Text", name="result", method="perform_operation"),
+    ]
+
+    def update_build_config(self, build_config, field_value, field_name=None):
+        dynamic_fields = [
+            "text",
+            "texts",
+            "delimiter",
+            "append_text",
+            "prepend_text",
+            "prefix",
+            "suffix",
+        ]
+        for field in dynamic_fields:
+            build_config[field]["show"] = False
+
+        if field_name == "operation":
+            if field_value == "Join Texts":
+                build_config["texts"]["show"] = True
+                build_config["delimiter"]["show"] = True
+            elif field_value == "Append":
+                build_config["text"]["show"] = True
+                build_config["append_text"]["show"] = True
+            elif field_value == "Prepend":
+                build_config["text"]["show"] = True
+                build_config["prepend_text"]["show"] = True
+            elif field_value == "Wrap":
+                build_config["text"]["show"] = True
+                build_config["prefix"]["show"] = True
+                build_config["suffix"]["show"] = True
+        return build_config
+
+    def perform_operation(self) -> Message:
+        operation = self.operation
+        if operation == "Join Texts":
+            delimiter = self.delimiter
+            texts = self.texts or []
+            result = delimiter.join(str(t) for t in texts)
+        elif operation == "Append":
+            result = f"{self.text or ''}{self.append_text or ''}"
+        elif operation == "Prepend":
+            result = f"{self.prepend_text or ''}{self.text or ''}"
+        elif operation == "Wrap":
+            result = f"{self.prefix or ''}{self.text or ''}{self.suffix or ''}"
+        else:
+            msg = f"Unsupported operation: {operation}"
+            raise ValueError(msg)
+
+        self.status = result
+        return Message(text=result)

--- a/src/backend/tests/unit/components/processing/test_text_operations_component.py
+++ b/src/backend/tests/unit/components/processing/test_text_operations_component.py
@@ -1,0 +1,40 @@
+import pytest
+from langflow.components.processing.text_operations import TextOperationsComponent
+from langflow.schema.message import Message
+
+from tests.base import ComponentTestBaseWithoutClient
+
+
+class TestTextOperationsComponent(ComponentTestBaseWithoutClient):
+    @pytest.fixture
+    def component_class(self):
+        return TextOperationsComponent
+
+    @pytest.fixture
+    def default_kwargs(self):
+        return {"operation": "Join Texts", "texts": ["a", "b"], "delimiter": ","}
+
+    @pytest.fixture
+    def file_names_mapping(self):
+        return []
+
+    def test_join_texts(self):
+        component = TextOperationsComponent(operation="Join Texts", texts=["Hello", "World"], delimiter=" ")
+        result = component.perform_operation()
+        assert isinstance(result, Message)
+        assert result.text == "Hello World"
+
+    def test_append(self):
+        component = TextOperationsComponent(operation="Append", text="Hello", append_text=" World")
+        result = component.perform_operation()
+        assert result.text == "Hello World"
+
+    def test_prepend(self):
+        component = TextOperationsComponent(operation="Prepend", text="World", prepend_text="Hello ")
+        result = component.perform_operation()
+        assert result.text == "Hello World"
+
+    def test_wrap(self):
+        component = TextOperationsComponent(operation="Wrap", text="middle", prefix="<", suffix=">")
+        result = component.perform_operation()
+        assert result.text == "<middle>"


### PR DESCRIPTION
## Summary
- add `JoinTextsComponent` to concatenate multiple text inputs with a delimiter
- make directory whitelist and blacklist filters multiline
- add `TextOperationsComponent` with join, append, prepend, and wrap modes
- test TextOperationsComponent

## Testing
- `ruff check --fix src/backend/base/langflow/components/processing/text_operations.py src/backend/base/langflow/components/processing/__init__.py src/backend/tests/unit/components/processing/test_text_operations_component.py src/backend/base/langflow/components/data/directory.py`
- `ruff format src/backend/base/langflow/components/processing/text_operations.py src/backend/base/langflow/components/processing/__init__.py src/backend/tests/unit/components/processing/test_text_operations_component.py src/backend/base/langflow/components/data/directory.py`
- `make unit_tests` *(fails: No route to host)*