### PR TITLE
Add structured outputs schema support

### DIFF
--- a/src/backend/base/langflow/components/models/openai_chat_model.py
+++ b/src/backend/base/langflow/components/models/openai_chat_model.py
@@ -1,3 +1,5 @@
+import json
+from collections import OrderedDict
 from typing import Any
 
 from langchain_openai import ChatOpenAI
@@ -10,8 +12,20 @@ from langflow.base.models.openai_constants import (
 )
 from langflow.field_typing import LanguageModel
 from langflow.field_typing.range_spec import RangeSpec
-from langflow.inputs import BoolInput, DictInput, DropdownInput, IntInput, SecretStrInput, SliderInput, StrInput
+from langflow.inputs import (
+    BoolInput,
+    DictInput,
+    DropdownInput,
+    IntInput,
+    NestedDictInput,
+    SecretStrInput,
+    SliderInput,
+    StrInput,
+)
+from langflow.io import Output
 from langflow.logging import logger
+from langflow.schema.data import Data
+from langflow.schema.dataframe import DataFrame
 
 
 class OpenAIModelComponent(LCModelComponent):
@@ -19,6 +33,22 @@ class OpenAIModelComponent(LCModelComponent):
     description = "Generates text using OpenAI LLMs."
     icon = "OpenAI"
     name = "OpenAIModel"
+
+    outputs = [
+        *LCModelComponent.outputs,
+        Output(
+            display_name="Structured Output",
+            name="structured_output",
+            method="structured_output",
+            hidden=True,
+        ),
+        Output(
+            display_name="DataFrame",
+            name="structured_output_dataframe",
+            method="structured_output_dataframe",
+            hidden=True,
+        ),
+    ]
 
     inputs = [
         *LCModelComponent._base_inputs,
@@ -40,6 +70,13 @@ class OpenAIModelComponent(LCModelComponent):
             display_name="JSON Mode",
             advanced=True,
             info="If True, it will output JSON regardless of passing a schema.",
+        ),
+        NestedDictInput(
+            name="response_schema",
+            display_name="Response Schema",
+            advanced=True,
+            input_types=["NestedDict"],
+            info="JSON schema for structured outputs.",
         ),
         DropdownInput(
             name="model_name",
@@ -115,7 +152,9 @@ class OpenAIModelComponent(LCModelComponent):
             parameters.pop("temperature")
             parameters.pop("seed")
         output = ChatOpenAI(**parameters)
-        if self.json_mode:
+        if self.response_schema:
+            output = output.bind(response_format={"type": "json_schema", **self.response_schema})
+        elif self.json_mode:
             output = output.bind(response_format={"type": "json_object"})
 
         return output
@@ -146,4 +185,28 @@ class OpenAIModelComponent(LCModelComponent):
         if field_name in {"base_url", "model_name", "api_key"} and field_value in OPENAI_MODEL_NAMES:
             build_config["temperature"]["show"] = True
             build_config["seed"]["show"] = True
+        schema = field_value if field_name == "response_schema" else self.response_schema
+        has_schema = bool(schema)
+        build_config["structured_output"]["hidden"] = not has_schema
+        build_config["structured_output_dataframe"]["hidden"] = not has_schema
         return build_config
+
+    def structured_output(self) -> Data:
+        if not self.response_schema:
+            return Data(data={})
+        result = self.text_response()
+        content = result.content if hasattr(result, "content") else result
+        try:
+            parsed = json.loads(content, object_pairs_hook=OrderedDict)
+        except Exception as exc:
+            msg = "Failed to parse structured output"
+            raise ValueError(msg) from exc
+        return Data(text_key="results", data={"results": parsed})
+
+    def structured_output_dataframe(self) -> DataFrame:
+        data = self.structured_output().data.get("results")
+        if isinstance(data, list):
+            return DataFrame(data=data)
+        if data is None:
+            return DataFrame()
+        return DataFrame(data=[data])

--- a/src/backend/base/langflow/components/models/openrouter.py
+++ b/src/backend/base/langflow/components/models/openrouter.py
@@ -1,4 +1,5 @@
-from collections import defaultdict
+import json
+from collections import OrderedDict, defaultdict
 from typing import Any
 
 import httpx
@@ -11,10 +12,14 @@ from langflow.field_typing.range_spec import RangeSpec
 from langflow.inputs import (
     DropdownInput,
     IntInput,
+    NestedDictInput,
     SecretStrInput,
     SliderInput,
     StrInput,
 )
+from langflow.io import Output
+from langflow.schema.data import Data
+from langflow.schema.dataframe import DataFrame
 
 
 class OpenRouterComponent(LCModelComponent):
@@ -25,6 +30,22 @@ class OpenRouterComponent(LCModelComponent):
         "OpenRouter provides unified access to multiple AI models from different providers through a single API."
     )
     icon = "OpenRouter"
+
+    outputs = [
+        *LCModelComponent.outputs,
+        Output(
+            display_name="Structured Output",
+            name="structured_output",
+            method="structured_output",
+            hidden=True,
+        ),
+        Output(
+            display_name="DataFrame",
+            name="structured_output_dataframe",
+            method="structured_output_dataframe",
+            hidden=True,
+        ),
+    ]
 
     inputs = [
         *LCModelComponent._base_inputs,
@@ -74,6 +95,13 @@ class OpenRouterComponent(LCModelComponent):
             display_name="Max Tokens",
             info="Maximum number of tokens to generate",
             advanced=True,
+        ),
+        NestedDictInput(
+            name="response_schema",
+            display_name="Response Schema",
+            advanced=True,
+            input_types=["NestedDict"],
+            info="JSON schema for structured outputs.",
         ),
     ]
 
@@ -143,11 +171,15 @@ class OpenRouterComponent(LCModelComponent):
             kwargs["default_headers"] = headers
 
         try:
-            return ChatOpenAI(**kwargs)
+            output = ChatOpenAI(**kwargs)
         except (ValueError, httpx.HTTPError) as err:
             error_msg = f"Failed to build model: {err!s}"
             self.log(error_msg)
             raise ValueError(error_msg) from err
+
+        if self.response_schema:
+            output = output.bind(response_format={"type": "json_schema", **self.response_schema})
+        return output
 
     def _get_exception_message(self, e: Exception) -> str | None:
         """Get a message from an OpenRouter exception.
@@ -198,5 +230,29 @@ class OpenRouterComponent(LCModelComponent):
             build_config["provider"]["value"] = "Error loading providers"
             build_config["model_name"]["options"] = ["Error loading models"]
             build_config["model_name"]["value"] = "Error loading models"
+        schema = field_value if field_name == "response_schema" else self.response_schema
+        has_schema = bool(schema)
+        build_config["structured_output"]["hidden"] = not has_schema
+        build_config["structured_output_dataframe"]["hidden"] = not has_schema
 
         return build_config
+
+    def structured_output(self) -> Data:
+        if not self.response_schema:
+            return Data(data={})
+        result = self.text_response()
+        content = result.content if hasattr(result, "content") else result
+        try:
+            parsed = json.loads(content, object_pairs_hook=OrderedDict)
+        except Exception as exc:
+            msg = "Failed to parse structured output"
+            raise ValueError(msg) from exc
+        return Data(text_key="results", data={"results": parsed})
+
+    def structured_output_dataframe(self) -> DataFrame:
+        data = self.structured_output().data.get("results")
+        if isinstance(data, list):
+            return DataFrame(data=data)
+        if data is None:
+            return DataFrame()
+        return DataFrame(data=[data])

--- a/src/backend/tests/unit/components/models/test_openai_chat_model.py
+++ b/src/backend/tests/unit/components/models/test_openai_chat_model.py
@@ -1,0 +1,43 @@
+from unittest.mock import MagicMock
+
+import pytest
+from langflow.components.models import OpenAIModelComponent
+
+from tests.base import ComponentTestBaseWithoutClient
+
+
+class TestOpenAIModelComponent(ComponentTestBaseWithoutClient):
+    @pytest.fixture
+    def component_class(self):
+        return OpenAIModelComponent
+
+    @pytest.fixture
+    def default_kwargs(self):
+        return {
+            "api_key": "test-key",
+            "model_name": "gpt-3.5-turbo",
+            "temperature": 0.1,
+            "max_tokens": 10,
+        }
+
+    @pytest.fixture
+    def file_names_mapping(self):
+        return []
+
+    def test_response_schema(self, component_class, mocker):
+        component = component_class()
+        component.api_key = "test-key"
+        component.response_schema = {
+            "name": "test",
+            "schema": {"type": "object", "properties": {}, "required": [], "additionalProperties": False},
+            "strict": True,
+        }
+        mock_instance = MagicMock()
+        mock_bound = MagicMock()
+        mock_instance.bind.return_value = mock_bound
+        mocker.patch("langflow.components.models.openai_chat_model.ChatOpenAI", return_value=mock_instance)
+
+        model = component.build_model()
+
+        mock_instance.bind.assert_called_once_with(response_format={"type": "json_schema", **component.response_schema})
+        assert model == mock_bound

--- a/src/backend/tests/unit/components/models/test_openrouter.py
+++ b/src/backend/tests/unit/components/models/test_openrouter.py
@@ -1,0 +1,44 @@
+from unittest.mock import MagicMock
+
+import pytest
+from langflow.components.models import OpenRouterComponent
+
+from tests.base import ComponentTestBaseWithoutClient
+
+
+class TestOpenRouterComponent(ComponentTestBaseWithoutClient):
+    @pytest.fixture
+    def component_class(self):
+        return OpenRouterComponent
+
+    @pytest.fixture
+    def default_kwargs(self):
+        return {
+            "api_key": "test-key",
+            "provider": "OpenAI",
+            "model_name": "openai/gpt-4o",
+            "temperature": 0.7,
+        }
+
+    @pytest.fixture
+    def file_names_mapping(self):
+        return []
+
+    def test_response_schema(self, component_class, mocker):
+        component = component_class()
+        component.api_key = "test-key"
+        component.model_name = "openai/gpt-4o"
+        component.response_schema = {
+            "name": "test",
+            "schema": {"type": "object", "properties": {}, "required": [], "additionalProperties": False},
+            "strict": True,
+        }
+        mock_instance = MagicMock()
+        mock_bound = MagicMock()
+        mock_instance.bind.return_value = mock_bound
+        mocker.patch("langflow.components.models.openrouter.ChatOpenAI", return_value=mock_instance)
+
+        model = component.build_model()
+
+        mock_instance.bind.assert_called_once_with(response_format={"type": "json_schema", **component.response_schema})
+        assert model == mock_bound


### PR DESCRIPTION
## Summary
- allow passing structured JSON schema through nested dict input
- add structured output and dataframe outputs that appear when a schema is supplied
- parse structured responses for OpenAI and OpenRouter nodes
- adjust unit tests

## Testing
- `ruff format src/backend/base/langflow/components/models/openai_chat_model.py src/backend/base/langflow/components/models/openrouter.py src/backend/tests/unit/components/models/test_openai_chat_model.py src/backend/tests/unit/components/models/test_openrouter.py`
- `ruff check src/backend/base/langflow/components/models/openai_chat_model.py src/backend/base/langflow/components/models/openrouter.py src/backend/tests/unit/components/models/test_openai_chat_model.py src/backend/tests/unit/components/models/test_openrouter.py`
- ❌ `pytest -k response_schema tests` *(fails: command not found)*