### PR TITLE
Add multi-text operations component

### DIFF
--- a/src/backend/base/langflow/components/data/directory.py
+++ b/src/backend/base/langflow/components/data/directory.py
@@ -6,8 +6,8 @@ from langflow.io import (
     BoolInput,
     IntInput,
     MessageTextInput,
+    MultilineInput,
     MultiselectInput,
-    StrInput,
 )
 from langflow.schema import Data
 from langflow.schema.dataframe import DataFrame
@@ -79,13 +79,13 @@ class DirectoryComponent(Component):
             advanced=True,
             info="If true, multithreading will be used.",
         ),
-        StrInput(
+        MultilineInput(
             name="whitelist_filters",
             display_name="Whitelist Filters",
             info="Regex patterns (one per line) to include specific files.",
             advanced=True,
         ),
-        StrInput(
+        MultilineInput(
             name="blacklist_filters",
             display_name="Blacklist Filters",
             info="Regex patterns (one per line) to exclude specific files.",

--- a/src/backend/base/langflow/components/processing/__init__.py
+++ b/src/backend/base/langflow/components/processing/__init__.py
@@ -17,6 +17,7 @@ from .parser import ParserComponent
 from .regex import RegexExtractorComponent
 from .select_data import SelectDataComponent
 from .split_text import SplitTextComponent
+from .text_operations import TextOperationsComponent
 from .update_data import UpdateDataComponent
 
 __all__ = [
@@ -40,5 +41,6 @@ __all__ = [
     "RegexExtractorComponent",
     "SelectDataComponent",
     "SplitTextComponent",
+    "TextOperationsComponent",
     "UpdateDataComponent",
 ]

--- a/src/backend/base/langflow/components/processing/text_operations.py
+++ b/src/backend/base/langflow/components/processing/text_operations.py
@@ -1,0 +1,129 @@
+from typing import Any
+
+from langflow.custom import Component
+from langflow.io import (
+    DropdownInput,
+    IntInput,
+    MessageTextInput,
+    MultilineInput,
+    Output,
+)
+from langflow.schema.dotdict import dotdict
+from langflow.schema.message import Message
+
+
+class TextOperationsComponent(Component):
+    """Perform simple text operations."""
+
+    display_name = "Text Operations"
+    description = "Append, prepend, wrap text, or concatenate multiple texts."
+    icon = "align-left"
+    name = "TextOperations"
+
+    OPERATION_CHOICES = ["Append", "Prepend", "Wrap", "Concat"]
+    MAX_TEXT_FIELDS = 10
+
+    inputs = [
+        MessageTextInput(
+            name="text",
+            display_name="Text",
+            info="Base text input.",
+            multiline=True,
+        ),
+        DropdownInput(
+            name="operation",
+            display_name="Operation",
+            options=OPERATION_CHOICES,
+            value="Append",
+            real_time_refresh=True,
+        ),
+        MultilineInput(
+            name="value",
+            display_name="Value",
+            info="String used for append, prepend, or wrap operations.",
+            show=True,
+        ),
+        MultilineInput(
+            name="delimiter",
+            display_name="Delimiter",
+            info="Delimiter used when concatenating texts.",
+            value="\n",
+            show=False,
+        ),
+        IntInput(
+            name="number_of_texts",
+            display_name="Number of Texts",
+            info="Number of text fields to concatenate.",
+            value=2,
+            dynamic=True,
+            show=False,
+        ),
+    ]
+
+    outputs = [
+        Output(display_name="Result", name="result", method="perform_operation"),
+    ]
+
+    def update_build_config(self, build_config: dotdict, field_value: Any, field_name: str | None = None) -> dotdict:
+        if field_name == "operation":
+            is_concat = field_value == "Concat"
+            build_config["text"]["show"] = not is_concat
+            build_config["value"]["show"] = field_value in {"Append", "Prepend", "Wrap"}
+            build_config["delimiter"]["show"] = is_concat
+            build_config["number_of_texts"]["show"] = is_concat
+
+            if not is_concat:
+                for key in list(build_config.keys()):
+                    if key.startswith("text_"):
+                        build_config.pop(key)
+            else:
+                number = int(build_config["number_of_texts"]["value"])
+                build_config = self._adjust_text_fields(build_config, number)
+        elif field_name == "number_of_texts":
+            try:
+                number = int(field_value)
+            except ValueError:
+                return build_config
+            build_config = self._adjust_text_fields(build_config, number)
+        return build_config
+
+    def _adjust_text_fields(self, build_config: dotdict, number: int) -> dotdict:
+        if number > self.MAX_TEXT_FIELDS:
+            number = self.MAX_TEXT_FIELDS
+            build_config["number_of_texts"]["value"] = number
+        existing = {k: v for k, v in build_config.items() if k.startswith("text_")}
+        # remove extra fields
+        for key in list(existing.keys()):
+            idx = int(key.split("_")[1])
+            if idx > number:
+                build_config.pop(key)
+        # add needed fields
+        for i in range(1, number + 1):
+            key = f"text_{i}"
+            if key not in build_config:
+                field = MultilineInput(name=key, display_name=f"Text {i}", multiline=True)
+                build_config[key] = field.to_dict()
+        return build_config
+
+    def perform_operation(self) -> Message:
+        operation = self.operation
+        if operation == "Append":
+            result = f"{self.text}{self.value}"
+        elif operation == "Prepend":
+            result = f"{self.value}{self.text}"
+        elif operation == "Wrap":
+            result = f"{self.value}{self.text}{self.value}"
+        elif operation == "Concat":
+            count = getattr(self, "number_of_texts", 0)
+            texts = []
+            for i in range(1, int(count) + 1):
+                attr = f"text_{i}"
+                text_val = getattr(self, attr, "")
+                texts.append(str(text_val))
+            result = self.delimiter.join(texts)
+        else:
+            msg = f"Unsupported operation: {operation}"
+            raise ValueError(msg)
+
+        self.status = result
+        return Message(text=result)

--- a/src/backend/tests/unit/components/processing/test_text_operations_component.py
+++ b/src/backend/tests/unit/components/processing/test_text_operations_component.py
@@ -1,0 +1,33 @@
+import pytest
+from langflow.components.processing.text_operations import TextOperationsComponent
+from langflow.schema.message import Message
+
+
+class TestTextOperationsComponent:
+    @pytest.mark.parametrize(
+        ("operation", "expected"),
+        [
+            ("Append", "HelloWorld"),
+            ("Prepend", "WorldHello"),
+            ("Wrap", "WorldHelloWorld"),
+        ],
+    )
+    def test_basic_operations(self, operation, expected):
+        comp = TextOperationsComponent()
+        comp.text = "Hello"
+        comp.operation = operation
+        comp.value = "World"
+        result = comp.perform_operation()
+        assert isinstance(result, Message)
+        assert result.text == expected
+
+    def test_concat_operation(self):
+        comp = TextOperationsComponent()
+        comp.operation = "Concat"
+        comp.delimiter = ","
+        comp.number_of_texts = 3
+        comp.text_1 = "A"
+        comp.text_2 = "B"
+        comp.text_3 = "C"
+        result = comp.perform_operation()
+        assert result.text == "A,B,C"


### PR DESCRIPTION
## Summary
- add dynamic `TextOperationsComponent` for append, prepend, wrap, and multi-text concatenation
- remove obsolete `JoinTextsComponent`
- expose new component in processing package
- update Directory whitelist/blacklist to accept multiline patterns
- add unit tests for the new text operations component

## Testing
- `ruff check --fix src/backend/base/langflow/components/processing/text_operations.py src/backend/base/langflow/components/processing/__init__.py src/backend/tests/unit/components/processing/test_text_operations_component.py src/backend/base/langflow/components/data/directory.py`
- `ruff format src/backend/base/langflow/components/processing/text_operations.py src/backend/base/langflow/components/processing/__init__.py src/backend/tests/unit/components/processing/test_text_operations_component.py src/backend/base/langflow/components/data/directory.py`
- `make unit_tests` *(fails: No route to host)*