### PR TITLE
Add structured outputs schema support

### DIFF
--- a/src/backend/base/langflow/components/models/openai_chat_model.py
+++ b/src/backend/base/langflow/components/models/openai_chat_model.py
@@ -41,6 +41,12 @@ class OpenAIModelComponent(LCModelComponent):
             advanced=True,
             info="If True, it will output JSON regardless of passing a schema.",
         ),
+        DictInput(
+            name="response_schema",
+            display_name="Response Schema",
+            advanced=True,
+            info="JSON schema for structured outputs.",
+        ),
         DropdownInput(
             name="model_name",
             display_name="Model Name",
@@ -115,7 +121,9 @@ class OpenAIModelComponent(LCModelComponent):
             parameters.pop("temperature")
             parameters.pop("seed")
         output = ChatOpenAI(**parameters)
-        if self.json_mode:
+        if self.response_schema:
+            output = output.bind(response_format={"type": "json_schema", "json_schema": self.response_schema})
+        elif self.json_mode:
             output = output.bind(response_format={"type": "json_object"})
 
         return output

--- a/src/backend/tests/unit/components/models/test_openai_chat_model.py
+++ b/src/backend/tests/unit/components/models/test_openai_chat_model.py
@@ -1,0 +1,44 @@
+from unittest.mock import MagicMock
+
+import pytest
+from langflow.components.models import OpenAIModelComponent
+from tests.base import ComponentTestBaseWithoutClient
+
+
+class TestOpenAIModelComponent(ComponentTestBaseWithoutClient):
+    @pytest.fixture
+    def component_class(self):
+        return OpenAIModelComponent
+
+    @pytest.fixture
+    def default_kwargs(self):
+        return {
+            "api_key": "test-key",
+            "model_name": "gpt-3.5-turbo",
+            "temperature": 0.1,
+            "max_tokens": 10,
+        }
+
+    @pytest.fixture
+    def file_names_mapping(self):
+        return []
+
+    def test_response_schema(self, component_class, mocker):
+        component = component_class()
+        component.api_key = "test-key"
+        component.response_schema = {
+            "name": "test",
+            "schema": {"type": "object", "properties": {}, "required": [], "additionalProperties": False},
+            "strict": True,
+        }
+        mock_instance = MagicMock()
+        mock_bound = MagicMock()
+        mock_instance.bind.return_value = mock_bound
+        mocker.patch("langflow.components.models.openai_chat_model.ChatOpenAI", return_value=mock_instance)
+
+        model = component.build_model()
+
+        mock_instance.bind.assert_called_once_with(
+            response_format={"type": "json_schema", "json_schema": component.response_schema}
+        )
+        assert model == mock_bound

--- a/src/backend/tests/unit/components/models/test_openrouter.py
+++ b/src/backend/tests/unit/components/models/test_openrouter.py
@@ -1,0 +1,45 @@
+from unittest.mock import MagicMock
+
+import pytest
+from langflow.components.models import OpenRouterComponent
+from tests.base import ComponentTestBaseWithoutClient
+
+
+class TestOpenRouterComponent(ComponentTestBaseWithoutClient):
+    @pytest.fixture
+    def component_class(self):
+        return OpenRouterComponent
+
+    @pytest.fixture
+    def default_kwargs(self):
+        return {
+            "api_key": "test-key",
+            "provider": "OpenAI",
+            "model_name": "openai/gpt-4o",
+            "temperature": 0.7,
+        }
+
+    @pytest.fixture
+    def file_names_mapping(self):
+        return []
+
+    def test_response_schema(self, component_class, mocker):
+        component = component_class()
+        component.api_key = "test-key"
+        component.model_name = "openai/gpt-4o"
+        component.response_schema = {
+            "name": "test",
+            "schema": {"type": "object", "properties": {}, "required": [], "additionalProperties": False},
+            "strict": True,
+        }
+        mock_instance = MagicMock()
+        mock_bound = MagicMock()
+        mock_instance.bind.return_value = mock_bound
+        mocker.patch("langflow.components.models.openrouter.ChatOpenAI", return_value=mock_instance)
+
+        model = component.build_model()
+
+        mock_instance.bind.assert_called_once_with(
+            response_format={"type": "json_schema", "json_schema": component.response_schema}
+        )
+        assert model == mock_bound


### PR DESCRIPTION
## Summary
- allow passing a JSON schema to OpenAI and OpenRouter nodes
- bind the structured schema to the ChatOpenAI instances
- add unit tests for the new schema feature
- fix schema binding to use `json_schema` key

## Testing
- `ruff format src/backend/base/langflow/components/models/openai_chat_model.py src/backend/base/langflow/components/models/openrouter.py src/backend/tests/unit/components/models/test_openai_chat_model.py src/backend/tests/unit/components/models/test_openrouter.py`
- `ruff check src/backend/base/langflow/components/models/openai_chat_model.py src/backend/base/langflow/components/models/openrouter.py src/backend/tests/unit/components/models/test_openai_chat_model.py src/backend/tests/unit/components/models/test_openrouter.py`
- ❌ `pytest -k response_schema tests` *(fails: command not found)*