### PR TITLE
Add multi-input text join component

### DIFF
--- a/src/backend/base/langflow/components/data/directory.py
+++ b/src/backend/base/langflow/components/data/directory.py
@@ -6,8 +6,8 @@ from langflow.io import (
     BoolInput,
     IntInput,
     MessageTextInput,
+    MultilineInput,
     MultiselectInput,
-    StrInput,
 )
 from langflow.schema import Data
 from langflow.schema.dataframe import DataFrame
@@ -79,13 +79,13 @@ class DirectoryComponent(Component):
             advanced=True,
             info="If true, multithreading will be used.",
         ),
-        StrInput(
+        MultilineInput(
             name="whitelist_filters",
             display_name="Whitelist Filters",
             info="Regex patterns (one per line) to include specific files.",
             advanced=True,
         ),
-        StrInput(
+        MultilineInput(
             name="blacklist_filters",
             display_name="Blacklist Filters",
             info="Regex patterns (one per line) to exclude specific files.",

--- a/src/backend/base/langflow/components/processing/__init__.py
+++ b/src/backend/base/langflow/components/processing/__init__.py
@@ -6,6 +6,7 @@ from .directory_tree import DirectoryTreeComponent
 from .extract_key import ExtractDataKeyComponent
 from .filter_data_values import DataFilterComponent
 from .format_directory_data import FormatDirectoryDataComponent
+from .join_texts import JoinTextsComponent
 from .json_cleaner import JSONCleaner
 from .lambda_filter import LambdaFilterComponent
 from .llm_router import LLMRouterComponent
@@ -29,6 +30,7 @@ __all__ = [
     "ExtractDataKeyComponent",
     "FormatDirectoryDataComponent",
     "JSONCleaner",
+    "JoinTextsComponent",
     "LLMRouterComponent",
     "LambdaFilterComponent",
     "MergeDataComponent",

--- a/src/backend/base/langflow/components/processing/join_texts.py
+++ b/src/backend/base/langflow/components/processing/join_texts.py
@@ -1,0 +1,37 @@
+from langflow.custom import Component
+from langflow.io import MessageTextInput, MultilineInput, Output
+from langflow.schema.message import Message
+
+
+class JoinTextsComponent(Component):
+    display_name = "Join Texts"
+    description = "Join multiple text inputs into a single text using a delimiter."
+    icon = "merge"
+    name = "JoinTexts"
+
+    inputs = [
+        MessageTextInput(
+            name="texts",
+            display_name="Texts",
+            info="List of texts to concatenate.",
+            is_list=True,
+        ),
+        MultilineInput(
+            name="delimiter",
+            display_name="Delimiter",
+            info="Delimiter used to join texts.",
+            value="\n",
+        ),
+    ]
+
+    outputs = [
+        Output(display_name="Combined Text", name="combined_text", method="join_texts"),
+    ]
+
+    def join_texts(self) -> Message:
+        text_list = self.texts or []
+        delimiter = self.delimiter
+        processed_texts = [text.text if isinstance(text, Message) else str(text) for text in text_list]
+        combined = delimiter.join(processed_texts)
+        self.status = combined
+        return Message(text=combined)

--- a/src/backend/tests/unit/components/data/test_directory_component.py
+++ b/src/backend/tests/unit/components/data/test_directory_component.py
@@ -420,8 +420,8 @@ class TestDirectoryComponent(ComponentTestBaseWithoutClient):
                     "recursive": True,
                     "types": ["txt"],
                     "silent_errors": False,
-                    "whitelist_filters": "include",
-                    "blacklist_filters": "exclude",
+                    "whitelist_filters": "include\nother",
+                    "blacklist_filters": "exclude\nignore",
                 }
             )
 

--- a/src/backend/tests/unit/components/processing/test_join_texts_component.py
+++ b/src/backend/tests/unit/components/processing/test_join_texts_component.py
@@ -1,0 +1,35 @@
+import pytest
+from langflow.components.processing import JoinTextsComponent
+from langflow.schema.message import Message
+
+from tests.base import ComponentTestBaseWithoutClient
+
+
+class TestJoinTextsComponent(ComponentTestBaseWithoutClient):
+    @pytest.fixture
+    def component_class(self):
+        return JoinTextsComponent
+
+    @pytest.fixture
+    def default_kwargs(self):
+        return {
+            "texts": [Message(text="a"), Message(text="b")],
+            "delimiter": "\n",
+        }
+
+    @pytest.fixture
+    def file_names_mapping(self):
+        return []
+
+    def test_join_texts_basic(self):
+        component = JoinTextsComponent(texts=[Message(text="one"), Message(text="two")], delimiter="-")
+        result = component.join_texts()
+        assert result.text == "one-two"
+
+    def test_join_texts_multiline_delimiter(self):
+        component = JoinTextsComponent(
+            texts=[Message(text="x"), Message(text="y"), Message(text="z")],
+            delimiter="---\n",
+        )
+        result = component.join_texts()
+        assert result.text == "x---\ny---\nz"


### PR DESCRIPTION
## Summary
- add JoinTextsComponent to merge multiple text inputs
- update DirectoryComponent regex filter test to use multi-line patterns
- add unit tests for JoinTextsComponent

## Testing
- `ruff check --fix src/backend/base/langflow/components/processing/join_texts.py src/backend/tests/unit/components/processing/test_join_texts_component.py src/backend/tests/unit/components/data/test_directory_component.py src/backend/base/langflow/components/data/directory.py src/backend/base/langflow/components/processing/__init__.py`
- `ruff format src/backend/base/langflow/components/processing/join_texts.py src/backend/tests/unit/components/processing/test_join_texts_component.py src/backend/tests/unit/components/data/test_directory_component.py src/backend/base/langflow/components/data/directory.py src/backend/base/langflow/components/processing/__init__.py`
- `make unit_tests` *(fails: No route to host)*