### PR TITLE
Fix OpenAI/OpenRouter json schema usage

### DIFF
--- a/src/backend/base/langflow/components/models/openai_chat_model.py
+++ b/src/backend/base/langflow/components/models/openai_chat_model.py
@@ -152,7 +152,7 @@ class OpenAIModelComponent(LCModelComponent):
             parameters.pop("seed")
         output = ChatOpenAI(**parameters)
         if self.response_schema:
-            output = output.bind(response_format={"type": "json_schema", **self.response_schema})
+            output = output.bind(response_format={"type": "json_schema", "json_schema": self.response_schema})
         elif self.json_mode:
             output = output.bind(response_format={"type": "json_object"})
 

--- a/src/backend/base/langflow/components/models/openrouter.py
+++ b/src/backend/base/langflow/components/models/openrouter.py
@@ -177,7 +177,7 @@ class OpenRouterComponent(LCModelComponent):
             raise ValueError(error_msg) from err
 
         if self.response_schema:
-            output = output.bind(response_format={"type": "json_schema", **self.response_schema})
+            output = output.bind(response_format={"type": "json_schema", "json_schema": self.response_schema})
         return output
 
     def structured_output(self) -> Data:

--- a/src/backend/tests/unit/components/models/test_openai_chat_model.py
+++ b/src/backend/tests/unit/components/models/test_openai_chat_model.py
@@ -39,7 +39,9 @@ class TestOpenAIModelComponent(ComponentTestBaseWithoutClient):
 
         model = component.build_model()
 
-        mock_instance.bind.assert_called_once_with(response_format={"type": "json_schema", **component.response_schema})
+        mock_instance.bind.assert_called_once_with(
+            response_format={"type": "json_schema", "json_schema": component.response_schema}
+        )
         assert model == mock_bound
 
     def test_update_build_config_outputs(self, component_class):

--- a/src/backend/tests/unit/components/models/test_openrouter.py
+++ b/src/backend/tests/unit/components/models/test_openrouter.py
@@ -40,7 +40,9 @@ class TestOpenRouterComponent(ComponentTestBaseWithoutClient):
 
         model = component.build_model()
 
-        mock_instance.bind.assert_called_once_with(response_format={"type": "json_schema", **component.response_schema})
+        mock_instance.bind.assert_called_once_with(
+            response_format={"type": "json_schema", "json_schema": component.response_schema}
+        )
         assert model == mock_bound
 
     def test_update_build_config_outputs(self, component_class):


### PR DESCRIPTION
## Summary
- fix parameter name when binding json schema in OpenAI/OpenRouter models
- update unit tests to check new response format

## Testing
- `ruff format src/backend/base/langflow/components/models/openai_chat_model.py src/backend/base/langflow/components/models/openrouter.py src/backend/tests/unit/components/models/test_openai_chat_model.py src/backend/tests/unit/components/models/test_openrouter.py`
- `ruff check src/backend/base/langflow/components/models/openai_chat_model.py src/backend/base/langflow/components/models/openrouter.py src/backend/tests/unit/components/models/test_openai_chat_model.py src/backend/tests/unit/components/models/test_openrouter.py`
- `make unit_tests` *(fails: No route to host)*