### PR TITLE
Fix JoinTexts dynamic inputs

### DIFF
--- a/src/backend/base/langflow/components/processing/join_texts.py
+++ b/src/backend/base/langflow/components/processing/join_texts.py
@@ -15,6 +15,7 @@ class JoinTextsComponent(Component):
             display_name="Texts",
             info="List of texts to concatenate.",
             is_list=True,
+            dynamic=True,
         ),
         MultilineInput(
             name="delimiter",


### PR DESCRIPTION
## Summary
- make JoinTexts inputs dynamic to provide separate handles for list entries

## Testing
- `make format` *(fails: No route to host)*
- `make unit_tests` *(fails: No route to host)*