### PR TITLE
Fix dataframe processing outputs

### DIFF
--- a/src/backend/base/langflow/components/processing/dataframe_operations.py
+++ b/src/backend/base/langflow/components/processing/dataframe_operations.py
@@ -258,8 +258,9 @@ class DataFrameOperationsComponent(Component):
         df_list = self.df if self._df_is_list() else [self.df]
         if len(df_list) < 2:
             return DataFrame(df_list[0]) if df_list else DataFrame()
-        appended = pd.concat(df_list, ignore_index=True)
-        return DataFrame(appended)
+        dataframes = [pd.DataFrame(df) for df in df_list]
+        appended = pd.concat(dataframes, ignore_index=True)
+        return DataFrame(appended.reset_index(drop=True))
 
     def merge_dataframes(self) -> DataFrame:
         if not self.merge_on:
@@ -268,7 +269,7 @@ class DataFrameOperationsComponent(Component):
         df_list = self.df if self._df_is_list() else [self.df]
         if len(df_list) < 2:
             return DataFrame(df_list[0]) if df_list else DataFrame()
-        merged = df_list[0]
+        merged = pd.DataFrame(df_list[0])
         for df in df_list[1:]:
-            merged = merged.merge(df, on=self.merge_on)
-        return DataFrame(merged)
+            merged = merged.merge(pd.DataFrame(df), on=self.merge_on)
+        return DataFrame(merged.reset_index(drop=True))

--- a/src/backend/tests/unit/components/processing/test_dataframe_operations.py
+++ b/src/backend/tests/unit/components/processing/test_dataframe_operations.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import pytest
 from langflow.components.processing.dataframe_operations import DataFrameOperationsComponent
+from langflow.schema import DataFrame
 
 
 @pytest.fixture
@@ -82,3 +83,26 @@ def test_invalid_operation():
     component.operation = "Invalid Operation"
     with pytest.raises(ValueError, match="Unsupported operation: Invalid Operation"):
         component.perform_operation()
+
+
+def test_append_operation():
+    df1 = pd.DataFrame({"A": [1], "B": [1]})
+    df2 = pd.DataFrame({"A": [2], "B": [2]})
+    component = DataFrameOperationsComponent()
+    component.df = [df1, df2]
+    component.operation = "Append"
+    result = component.perform_operation()
+    assert isinstance(result, DataFrame)
+    assert len(result) == 2
+
+
+def test_merge_operation():
+    df1 = pd.DataFrame({"id": [1], "A": [1]})
+    df2 = pd.DataFrame({"id": [1], "B": [2]})
+    component = DataFrameOperationsComponent()
+    component.df = [df1, df2]
+    component.operation = "Merge"
+    component.merge_on = "id"
+    result = component.perform_operation()
+    assert isinstance(result, DataFrame)
+    assert set(result.columns) == {"id", "A", "B"}


### PR DESCRIPTION
## Summary
- handle pandas inputs when appending/merging DataFrames
- add regression tests for append and merge operations

## Testing
- `pytest -q src/backend/tests/unit/components/processing/test_dataframe_operations.py` *(fails: `pytest: command not found`)*