### PR TITLE
Fix DataFrame outputs and update data join

### DIFF
--- a/src/backend/base/langflow/schema/artifact.py
+++ b/src/backend/base/langflow/schema/artifact.py
@@ -68,7 +68,9 @@ def post_process_raw(raw, artifact_type: str):
     if artifact_type == ArtifactType.STREAM.value:
         raw = ""
     elif artifact_type == ArtifactType.ARRAY.value:
-        raw = raw.to_dict(orient="records") if isinstance(raw, DataFrame) else _to_list_of_dicts(raw)
+        # Keep DataFrame objects intact for proper frontend rendering
+        # Convert lists of objects to a serializable format otherwise
+        raw = raw if isinstance(raw, DataFrame) else _to_list_of_dicts(raw)
     elif artifact_type == ArtifactType.UNKNOWN.value and raw is not None:
         if isinstance(raw, BaseModel | dict):
             try:

--- a/src/backend/base/langflow/schema/schema.py
+++ b/src/backend/base/langflow/schema/schema.py
@@ -36,7 +36,7 @@ class ErrorLog(TypedDict):
 
 
 class OutputValue(BaseModel):
-    message: ErrorLog | StreamURL | dict | list | str
+    message: ErrorLog | StreamURL | dict | list | str | DataFrame
     type: str
 
 
@@ -108,9 +108,9 @@ def build_output_logs(vertex, result) -> dict:
                 message = ""
 
             case LogType.ARRAY:
-                if isinstance(message, DataFrame):
-                    message = message.to_dict(orient="records")
-                message = [serialize(item) for item in message]
+                # Keep DataFrame objects untouched for proper table display
+                if not isinstance(message, DataFrame):
+                    message = [serialize(item) for item in message]
         name = output.get("name", f"output_{index}")
         outputs |= {name: OutputValue(message=message, type=type_).model_dump()}
 


### PR DESCRIPTION
## Summary
- keep DataFrame objects in artifacts and output logs
- allow OutputValue to hold DataFrame values
- update Data operations join to return a DataFrame

## Testing
- `ruff check src/backend/base/langflow/components/processing/data_operations.py src/backend/base/langflow/schema/artifact.py src/backend/base/langflow/schema/schema.py`