### PR TITLE
Fix OutputValue DataFrame handling

### DIFF
--- a/src/backend/base/langflow/schema/artifact.py
+++ b/src/backend/base/langflow/schema/artifact.py
@@ -68,7 +68,9 @@ def post_process_raw(raw, artifact_type: str):
     if artifact_type == ArtifactType.STREAM.value:
         raw = ""
     elif artifact_type == ArtifactType.ARRAY.value:
-        raw = raw.to_dict(orient="records") if isinstance(raw, DataFrame) else _to_list_of_dicts(raw)
+        # Keep DataFrame objects intact for proper frontend rendering
+        # Convert lists of objects to a serializable format otherwise
+        raw = raw if isinstance(raw, DataFrame) else _to_list_of_dicts(raw)
     elif artifact_type == ArtifactType.UNKNOWN.value and raw is not None:
         if isinstance(raw, BaseModel | dict):
             try:


### PR DESCRIPTION
## Summary
- allow OutputValue to store DataFrame objects by enabling `arbitrary_types_allowed`
- keep DataFrame objects intact when post-processing artifacts
- let join operation of DataOperationsComponent return a DataFrame

## Testing
- `ruff check src/backend/base/langflow/components/processing/data_operations.py src/backend/base/langflow/schema/artifact.py src/backend/base/langflow/schema/schema.py`