### PR TITLE
Fix dynamic list handle IDs

### DIFF
--- a/src/frontend/src/CustomNodes/utils/get-handle-id.tsx
+++ b/src/frontend/src/CustomNodes/utils/get-handle-id.tsx
@@ -20,11 +20,13 @@ export function getLeftHandleId({
   type,
   fieldName,
   id,
+  index,
 }: targetHandleType): string {
   return scapedJSONStringfy({
     inputTypes,
     id,
     type,
     fieldName,
+    ...(index !== undefined ? { index } : {}),
   });
 }

--- a/src/frontend/src/types/flow/index.ts
+++ b/src/frontend/src/types/flow/index.ts
@@ -111,4 +111,5 @@ export type targetHandleType = {
   name?: string;
   id: string;
   proxy?: { field: string; id: string };
+  index?: number;
 };

--- a/src/frontend/src/utils/reactflowUtils.ts
+++ b/src/frontend/src/utils/reactflowUtils.ts
@@ -122,6 +122,9 @@ export function cleanEdges(nodes: AllNodeType[], edges: EdgeType[]) {
           id: targetNode.data.id,
           inputTypes: inputTypes,
         };
+        if (targetHandleObject.index !== undefined) {
+          ;(id as targetHandleType).index = targetHandleObject.index
+        }
         if (hasProxy) {
           id.proxy = targetNode.data.node!.template[field]?.proxy;
         }


### PR DESCRIPTION
## Summary
- preserve index in target handle id type
- include index when generating left handle IDs
- retain index while validating existing edges

## Testing
- `make unit_tests` *(fails: No route to host)*